### PR TITLE
use latest version of ssh agent that gets off deprecated api in github ci

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Add the ssh-key to the keyring in order to clone repos
-      - uses: webfactory/ssh-agent@v0.2.0
+      - uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.ssh_key }}
 


### PR DESCRIPTION
Should fix failed deployments https://github.com/alantech/docs/actions/runs/379566459 from old version of webfactory/ssh-agent not complying with https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/